### PR TITLE
Ensure End of List Link Retrieved for Same Project

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,9 +8,8 @@
     "esbenp.prettier-vscode",
     "gruntfuggly.todo-tree",
     "jock.svg",
-    "orta.vscode-jest",
     "ryanluker.vscode-coverage-gutters",
-    "vscode-icons-team.vscode-icons"
+    "firsttris.vscode-jest-runner"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/atoll-mono.code-workspace
+++ b/atoll-mono.code-workspace
@@ -53,7 +53,8 @@
         "coverage-gutters.showLineCoverage": false,
         "typescript.tsdk": "node_modules\\typescript\\lib",
         "deno.enable": false,
-        "jest.disabledWorkspaceFolders": ["vscode-extension", "shared", "scripts", "rich-types", "api-types"]
+        "jest.disabledWorkspaceFolders": ["vscode-extension", "shared", "scripts", "rich-types", "api-types"],
+        "jestrunner.jestPath": "${workspaceFolder:web-app}/../../../node_modules/jest/bin/jest.js"
     },
     "extensions": {
         "recommendations": ["bierner.markdown-checkbox"]

--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
     "test": "npm run test-all",
     "test-all": "npm run test -ws --if-present",
     "test-all:unit": "npm run test:unit -ws --if-present",
-    "test-pkg:shared": "npm run test -w packagesnp/shared",
-    "test-pkg:extension": "npm run test -w packages/vscode-extension"
+    "test-pkg:shared": "npm run test -w packages/shared",
+    "test-pkg:extension": "npm run test -w packages/vscode-extension",
+    "test-pkg:web-app": "npm run test -w packages/web-app"
   },
   "author": {
     "name": "Kevin Berry",

--- a/packages/api-types/tsconfig.json
+++ b/packages/api-types/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
   "include": ["src/**/*.ts*"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "__common__/**/*.ts*"]
 }

--- a/packages/client-sdk/tsconfig.json
+++ b/packages/client-sdk/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
   "include": ["src/**/*.ts*"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "__common__/**/*.ts*"]
 }

--- a/packages/rest-fetch/tsconfig.json
+++ b/packages/rest-fetch/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
   "include": ["src/**/*.ts*"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "__common__/**/*.ts*"]
 }

--- a/packages/rich-types/tsconfig.json
+++ b/packages/rich-types/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
   "include": ["src/**/*.ts*"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "__common__/**/*.ts*"]
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
   "include": ["src/**/*.ts*"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "__common__/**/*.ts*"]
 }

--- a/packages/web-app/src/server/api/handlers/__common__/linkedListArraySorter.ts
+++ b/packages/web-app/src/server/api/handlers/__common__/linkedListArraySorter.ts
@@ -1,0 +1,44 @@
+export const sortLinkedListArray = (collection: any[], idFieldName: string, nextIdFieldName: string, groupFieldName: string) => {
+    const result: any[] = [];
+    const groupFieldNames: Record<string, any[]> = {};
+    collection.forEach((item) => {
+        const groupFieldNameValue = item[groupFieldName];
+        let groupFieldCollection = groupFieldNames[groupFieldNameValue];
+        if (groupFieldCollection === undefined) {
+            groupFieldNames[groupFieldNameValue] = [];
+            groupFieldCollection = groupFieldNames[groupFieldNameValue];
+        }
+        groupFieldCollection.push(item);
+    });
+    Object.keys(groupFieldNames).forEach((groupFieldName) => {
+        const groupFieldCollection = groupFieldNames[groupFieldName];
+        const collectionByIdField: Record<string, any[]> = {};
+        groupFieldCollection.forEach((item) => {
+            collectionByIdField[item[idFieldName]] = item;
+        });
+        const matchingStartItems = groupFieldCollection.filter((item) => item[idFieldName] === null);
+        if (matchingStartItems.length > 1) {
+            throw new Error("Unexpected condition- more than one starting item!");
+        } else if (matchingStartItems.length === 0) {
+            throw new Error("Unexpected condition- no starting items!");
+        } else {
+            let currentItem = matchingStartItems[0];
+            let busy = true;
+            let count = 0;
+            let maxCount = 1000;
+            while (busy) {
+                result.push(currentItem);
+                const nextItemId = currentItem[nextIdFieldName];
+                if (nextItemId === null) {
+                    busy = false;
+                } else if (count > maxCount) {
+                    throw new Error(`Unexpected condition- looped through ${count} items!`);
+                } else {
+                    currentItem = collectionByIdField[nextItemId];
+                }
+                count++;
+            }
+        }
+    });
+    return result;
+};

--- a/packages/web-app/src/server/api/handlers/__common__/mockDatabase.ts
+++ b/packages/web-app/src/server/api/handlers/__common__/mockDatabase.ts
@@ -1,0 +1,49 @@
+export type CollectionEntry = Record<string, any>;
+export class MockDatabase {
+    private collections: Record<string, CollectionEntry[]>;
+    constructor() {}
+    reset() {
+        this.collections = {};
+    }
+    addCollection = (collectionName: string, values: CollectionEntry[]) => {
+        this.collections[collectionName] = values;
+    };
+    getCollectionItem = <T>(collectionName: string, fieldName: string, fieldValue: string): any => {
+        const itemValue = this.getCollectionItemValueByValues(collectionName, { [fieldName]: fieldValue });
+        return itemValue;
+        // const collectionItems: CollectionEntry[] = this.collections[collectionName];
+        // const matchingItems = collectionItems.filter((item) => item[fieldName] === fieldValue);
+        // return matchingItems[0]?.value;
+    };
+    getCollectionItemValueByValues = (collectionName: string, values: Record<string, any>): any | undefined => {
+        const items: CollectionEntry[] = this.getCollectionItemsByValues(collectionName, values);
+        return items[0];
+    };
+    getCollectionItemsByValues = (collectionName: string, values: Record<string, any>): CollectionEntry[] => {
+        const collectionItems: CollectionEntry[] = this.collections[collectionName];
+        const matchingItems = collectionItems.filter((item) => {
+            const fieldNames = Object.keys(values);
+            let matches = fieldNames.length > 0;
+            fieldNames.forEach((fieldName: string) => {
+                const value = values[fieldName];
+                if (item[fieldName] !== value) {
+                    matches = false;
+                }
+            });
+            return matches;
+        });
+        return matchingItems;
+    };
+    updateItem = (collectionName: string, whereValues: Record<string, any>, updateValues: Record<string, any>) => {
+        const items = this.getCollectionItemsByValues(collectionName, whereValues);
+        items.forEach((item) => {
+            const fieldNames = Object.keys(updateValues);
+            fieldNames.forEach((fieldName) => {
+                item[fieldName] = updateValues[fieldName];
+            });
+        });
+    };
+    getAllCollectionValues = (collectionName: string) => {
+        return this.collections[collectionName];
+    };
+}

--- a/packages/web-app/src/server/api/handlers/__common__/mockDatabase.ts
+++ b/packages/web-app/src/server/api/handlers/__common__/mockDatabase.ts
@@ -11,9 +11,6 @@ export class MockDatabase {
     getCollectionItem = <T>(collectionName: string, fieldName: string, fieldValue: string): any => {
         const itemValue = this.getCollectionItemValueByValues(collectionName, { [fieldName]: fieldValue });
         return itemValue;
-        // const collectionItems: CollectionEntry[] = this.collections[collectionName];
-        // const matchingItems = collectionItems.filter((item) => item[fieldName] === fieldValue);
-        // return matchingItems[0]?.value;
     };
     getCollectionItemValueByValues = (collectionName: string, values: Record<string, any>): any | undefined => {
         const items: CollectionEntry[] = this.getCollectionItemsByValues(collectionName, values);

--- a/packages/web-app/src/server/api/handlers/__tests__/backlogItems.test.ts
+++ b/packages/web-app/src/server/api/handlers/__tests__/backlogItems.test.ts
@@ -204,5 +204,176 @@ describe("Backlog Items", () => {
                 }
             ]);
         });
+        /**
+         * This test is a special case because the end of the list is designated
+         * by a null link.  The reorder operation inserts the source item BEFORE
+         * the target provided.  So, in order to add to the end of the list the
+         * target provided will be null, but that can match any of the
+         * "end of list" items because there could be more than one project in
+         * the list.  To simulate this properly 3 projects are included.
+         */
+        it("should handle reorder scenario to end of list", async () => {
+            const project0Items = [
+                {
+                    backlogitemId: null,
+                    nextbacklogitemId: "X",
+                    projectId: "PROJECT_0"
+                },
+                {
+                    backlogitemId: "X",
+                    nextbacklogitemId: "Y",
+                    projectId: "PROJECT_0"
+                },
+                {
+                    backlogitemId: "Y",
+                    nextbacklogitemId: "Z",
+                    projectId: "PROJECT_0"
+                },
+                {
+                    backlogitemId: "Z",
+                    nextbacklogitemId: null,
+                    projectId: "PROJECT_0"
+                }
+            ];
+            const project2Items = [
+                {
+                    backlogitemId: null,
+                    nextbacklogitemId: "P",
+                    projectId: "PROJECT_2"
+                },
+                {
+                    backlogitemId: "P",
+                    nextbacklogitemId: "Q",
+                    projectId: "PROJECT_2"
+                },
+                {
+                    backlogitemId: "Q",
+                    nextbacklogitemId: "R",
+                    projectId: "PROJECT_2"
+                },
+                {
+                    backlogitemId: "R",
+                    nextbacklogitemId: null,
+                    projectId: "PROJECT_2"
+                }
+            ];
+            mockDatabase.addCollection("productbacklogitems", [
+                ...project0Items,
+                {
+                    backlogitemId: null,
+                    nextbacklogitemId: "A",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "A",
+                    nextbacklogitemId: "B",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "B",
+                    nextbacklogitemId: "C",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "C",
+                    nextbacklogitemId: "D",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "D",
+                    nextbacklogitemId: "E",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "E",
+                    nextbacklogitemId: "F",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "F",
+                    nextbacklogitemId: null,
+                    projectId: "PROJECT_1"
+                },
+                ...project2Items
+            ]);
+            // arrange
+            const req: Request = {
+                body: {
+                    sourceItemId: "B", // source is used to determine project ID
+                    targetItemId: null // move to end of list
+                }
+            } as any;
+            const res: Response = {
+                status: statusFn
+            } as any;
+            const findOneSpy = jest.spyOn(ProductBacklogItemDataModel, "findOne");
+            const updateSpy = jest.spyOn(ProductBacklogItemDataModel, "update");
+            updateSpy.mockImplementation(() => null);
+            findOneSpy.mockImplementation((options) => {
+                const item = mockDatabase.getCollectionItemValueByValues("productbacklogitems", options.where);
+                return Promise.resolve({
+                    dataValues: {
+                        ...item
+                    },
+                    update: (updateValues, options) => {
+                        mockDatabase.updateItem("productbacklogitems", item, updateValues);
+                    }
+                } as any);
+            });
+
+            // act
+            await backlogItemsReorderPostHandler(req, res);
+
+            // assert
+            expect(findOneSpy).toBeCalledTimes(3);
+            expect(sequelizeTransactionCommmitMock).toBeCalledTimes(1);
+            expect(sequelizeTransactionRollbackMock).toBeCalledTimes(0);
+            const allCollectionValuesRaw = mockDatabase.getAllCollectionValues("productbacklogitems");
+            const allCollectionValues = sortLinkedListArray(
+                allCollectionValuesRaw,
+                "backlogitemId",
+                "nextbacklogitemId",
+                "projectId"
+            );
+            expect(allCollectionValues).toStrictEqual([
+                ...project0Items,
+                {
+                    backlogitemId: null,
+                    nextbacklogitemId: "A",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "A",
+                    nextbacklogitemId: "C",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "C",
+                    nextbacklogitemId: "D",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "D",
+                    nextbacklogitemId: "E",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "E",
+                    nextbacklogitemId: "F",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "F",
+                    nextbacklogitemId: "B",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "B",
+                    nextbacklogitemId: null,
+                    projectId: "PROJECT_1"
+                },
+                ...project2Items
+            ]);
+        });
     });
 });

--- a/packages/web-app/src/server/api/handlers/__tests__/backlogItems.test.ts
+++ b/packages/web-app/src/server/api/handlers/__tests__/backlogItems.test.ts
@@ -1,0 +1,208 @@
+// test related
+import "jest";
+
+// interfaces/types
+import type { Request, Response } from "express";
+import { Transaction } from "sequelize";
+
+// mock related
+import { ProductBacklogItemDataModel } from "../../../dataaccess/models/ProductBacklogItemDataModel";
+import { MockDatabase } from "../__common__/mockDatabase";
+import { sequelize } from "../../../dataaccess/connection";
+
+// code under test
+import { backlogItemsReorderPostHandler } from "../backlogItems";
+
+// test utils
+import { sortLinkedListArray } from "../__common__/linkedListArraySorter";
+
+describe("Backlog Items", () => {
+    let sendFn: jest.Mock;
+    let statusFn: jest.Mock;
+    let sequelizeTransactionCommmitMock: jest.Mock;
+    let sequelizeTransactionRollbackMock: jest.Mock;
+    const mockDatabase: MockDatabase = new MockDatabase();
+    beforeEach(() => {
+        mockDatabase.reset();
+        sendFn = jest.fn(() => null);
+        statusFn = jest.fn(() => ({
+            send: sendFn
+        }));
+        sequelizeTransactionCommmitMock = jest.fn(async () => undefined);
+        sequelizeTransactionRollbackMock = jest.fn(async () => undefined);
+        const sequelizeTransactionSpy = jest.spyOn(sequelize, "transaction");
+        const sequelizeTransactionMock: Promise<Transaction> = {
+            commit: sequelizeTransactionCommmitMock,
+            rollback: sequelizeTransactionRollbackMock
+        } as any;
+        sequelizeTransactionSpy.mockResolvedValue(sequelizeTransactionMock);
+    });
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+    describe("backlogitemsReorderPostHandler", () => {
+        it("should respond with failed validation if sourceItemId is undefined", async () => {
+            // arrange
+            const req: Request = {
+                body: {
+                    sourceItemId: undefined,
+                    targetItemId: "F"
+                }
+            } as any;
+            const res: Response = {
+                status: statusFn
+            } as any;
+
+            // act
+            await backlogItemsReorderPostHandler(req, res);
+
+            // assert
+            expect(statusFn).toBeCalledWith(400);
+            expect(sendFn).toBeCalledWith({
+                message: "sourceItemId must have a value",
+                status: 400
+            });
+            expect(sequelizeTransactionCommmitMock).toBeCalledTimes(0);
+            expect(sequelizeTransactionRollbackMock).toBeCalledTimes(0);
+        });
+        it("should respond with failed validation if sourceItemId = targetItemId", async () => {
+            // arrange
+            const req: Request = {
+                body: {
+                    sourceItemId: "B",
+                    targetItemId: "B"
+                }
+            } as any;
+            const res: Response = {
+                status: statusFn
+            } as any;
+
+            // act
+            await backlogItemsReorderPostHandler(req, res);
+
+            // assert
+            expect(statusFn).toBeCalledWith(400);
+            expect(sendFn).toBeCalledWith({
+                message: "sourceItemId and targetItemId must be different!",
+                status: 400
+            });
+            expect(sequelizeTransactionCommmitMock).toBeCalledTimes(0);
+            expect(sequelizeTransactionRollbackMock).toBeCalledTimes(0);
+        });
+        it("should handle a simple reorder scenario", async () => {
+            mockDatabase.addCollection("productbacklogitems", [
+                {
+                    backlogitemId: null,
+                    nextbacklogitemId: "A",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "A",
+                    nextbacklogitemId: "B",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "B",
+                    nextbacklogitemId: "C",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "C",
+                    nextbacklogitemId: "D",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "D",
+                    nextbacklogitemId: "E",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "E",
+                    nextbacklogitemId: "F",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "F",
+                    nextbacklogitemId: null,
+                    projectId: "PROJECT_1"
+                }
+            ]);
+            // arrange
+            const req: Request = {
+                body: {
+                    sourceItemId: "B",
+                    targetItemId: "F"
+                }
+            } as any;
+            const res: Response = {
+                status: statusFn
+            } as any;
+            const findOneSpy = jest.spyOn(ProductBacklogItemDataModel, "findOne");
+            const updateSpy = jest.spyOn(ProductBacklogItemDataModel, "update");
+            updateSpy.mockImplementation(() => null);
+            findOneSpy.mockImplementation((options) => {
+                const item = mockDatabase.getCollectionItemValueByValues("productbacklogitems", options.where);
+                return Promise.resolve({
+                    dataValues: {
+                        ...item
+                    },
+                    update: (updateValues, options) => {
+                        mockDatabase.updateItem("productbacklogitems", item, updateValues);
+                    }
+                } as any);
+            });
+
+            // act
+            await backlogItemsReorderPostHandler(req, res);
+
+            // assert
+            expect(findOneSpy).toBeCalledTimes(3);
+            expect(sequelizeTransactionCommmitMock).toBeCalledTimes(1);
+            expect(sequelizeTransactionRollbackMock).toBeCalledTimes(0);
+            const allCollectionValuesRaw = mockDatabase.getAllCollectionValues("productbacklogitems");
+            const allCollectionValues = sortLinkedListArray(
+                allCollectionValuesRaw,
+                "backlogitemId",
+                "nextbacklogitemId",
+                "projectId"
+            );
+            expect(allCollectionValues).toStrictEqual([
+                {
+                    backlogitemId: null,
+                    nextbacklogitemId: "A",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "A",
+                    nextbacklogitemId: "C",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "C",
+                    nextbacklogitemId: "D",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "D",
+                    nextbacklogitemId: "E",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "E",
+                    nextbacklogitemId: "B",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "B",
+                    nextbacklogitemId: "F",
+                    projectId: "PROJECT_1"
+                },
+                {
+                    backlogitemId: "F",
+                    nextbacklogitemId: null,
+                    projectId: "PROJECT_1"
+                }
+            ]);
+        });
+    });
+});

--- a/packages/web-app/src/server/api/handlers/backlogItems.ts
+++ b/packages/web-app/src/server/api/handlers/backlogItems.ts
@@ -413,11 +413,12 @@ export const backlogItemsReorderPostHandler = async (req: Request, res: Response
         transaction = await sequelize.transaction({ isolationLevel: Transaction.ISOLATION_LEVELS.SERIALIZABLE });
 
         // 1. Unlink source item from old location
-        const sourceItemPrevLink = await ProductBacklogItemDataModel.findOne({
-            where: { nextbacklogitemId: sourceItemId }
-        });
         const sourceItemNextLink = await ProductBacklogItemDataModel.findOne({
             where: { backlogitemId: sourceItemId }
+        });
+        const projectId = (sourceItemNextLink as any).dataValues.projectId;
+        const sourceItemPrevLink = await ProductBacklogItemDataModel.findOne({
+            where: { nextbacklogitemId: sourceItemId, projectId }
         });
         const oldNextItemId = (sourceItemNextLink as any).dataValues.nextbacklogitemId;
         const sourceItemPrevLinkId = (sourceItemPrevLink as any).dataValues.backlogitemId;
@@ -428,7 +429,7 @@ export const backlogItemsReorderPostHandler = async (req: Request, res: Response
 
         // 2. Re-link source item in new location
         const targetItemPrevLink = await ProductBacklogItemDataModel.findOne({
-            where: { nextbacklogitemId: targetItemId }
+            where: { nextbacklogitemId: targetItemId, projectId }
         });
         const targetItemPrevLinkId = (targetItemPrevLink as any).dataValues.backlogitemId;
         if (targetItemPrevLinkId === sourceItemId) {

--- a/packages/web-app/src/server/dataaccess/mappers/__tests__/apiToDataAccessMappers.test.ts
+++ b/packages/web-app/src/server/dataaccess/mappers/__tests__/apiToDataAccessMappers.test.ts
@@ -14,7 +14,7 @@ import { ApiBacklogItem, ApiBacklogItemPart } from "@atoll/shared";
 
 describe("API To Data Object Mappers", () => {
     describe("mapApiToDbBacklogItem", () => {
-        it("should map a sample backlog item correctly", () => {
+        it("should map a sample backlog item to db model correctly", () => {
             // arrange
             const apiItem: ApiBacklogItem = {
                 id: "fake-id",
@@ -49,7 +49,7 @@ describe("API To Data Object Mappers", () => {
             // assert
             const shellDbItem = {
                 acceptanceCriteria: "* successfully test this mapping function",
-                notes: "* successfully test notes db mapping",
+                notes: "* successfully test notes mapping",
                 acceptedAt: new Date("2022-04-06T14:45:15.767Z"),
                 createdAt: new Date("2022-04-02T09:59:01.000Z"),
                 estimate: 13,

--- a/packages/web-app/src/server/dataaccess/mappers/__tests__/dataAccessToApiMappers.test.ts
+++ b/packages/web-app/src/server/dataaccess/mappers/__tests__/dataAccessToApiMappers.test.ts
@@ -47,7 +47,7 @@ describe("Data Object To API Mappers", () => {
         });
     });
     describe("mapDbToApiBacklogItem", () => {
-        it("should map a sample backlog item correctly", () => {
+        it("should map a sample backlog item to api model correctly", () => {
             // arrange
             const shellDbItem = {
                 id: "fake-id",


### PR DESCRIPTION
The drag-and-drop to end of list issue was caused because of a unique aspect of dragging to the end of the list:
1. The backlog item rank is managed by what is essentially a linked list persisted in the database (ID -> Next ID pairs in each row).
2. The beginning of the list is defined by a (null -> First ID) pair.  The end of the list by a (Last ID -> null) pair.
3. Since Atoll supports multiple projects the rank table there are multiple start and end rows.
4. As a consequence, when searching for an ID that represents the end of the list it involves a null search.  That's where the problem comes in- it can match multiple rows and the logic wasn't erroring out in this case.  Instead it was just picking the first entry it found.

So, the simple fix was to make sure it only searched for the end of the list with the same Project ID as the item being dragged to the end of the list.

This PR fixes issue https://github.com/51ngul4r1ty/atoll-core/issues/496.